### PR TITLE
CreateCommand did not eliminate static ctors

### DIFF
--- a/src/NConsole/CommandLineProcessor.cs
+++ b/src/NConsole/CommandLineProcessor.cs
@@ -200,7 +200,7 @@ namespace NConsole
 
             if (constructors.Any())
             {
-                var constructor = constructors.First();
+                var constructor = constructors.First(c => !c.IsStatic);
 
                 if (constructor.GetParameters().Length > 0 && _dependencyResolver == null)
                     throw new InvalidOperationException("No dependency resolver available to create a command without default constructor.");


### PR DESCRIPTION
As a result a class with a static ctor would cause
'System.MemberAccessException: Type initializer was not callable.'
Eliminate static ctors from consideration
Add tests to confirm bug and then fix
Remove unused 'using' from CommandLineProcessorTests.cs
Fix incorrect cast/null test in
When_first_argument_is_existing_command_name_then_command_is_executed