### PR TITLE
Add exception for unexpected arguments

### DIFF
--- a/src/NConsole.Tests/NConsole.Tests.csproj
+++ b/src/NConsole.Tests/NConsole.Tests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="EnumArgumentTests.cs" />
     <Compile Include="PositionArgumentTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UnexpectedArgumentsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\NConsole.snk">

--- a/src/NConsole.Tests/UnexpectedArgumentsTests.cs
+++ b/src/NConsole.Tests/UnexpectedArgumentsTests.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace NConsole.Tests
+{
+    [TestClass]
+    public class UnexpectedArgumentsTests
+    {
+        [TestMethod]
+        public async Task When_running_command_with_full_datetime_parameter_then_they_are_correctly_set()
+        {
+            //// Arrange
+            var processor = new CommandLineProcessor(new ConsoleHost());
+            processor.RegisterCommand<MyArgumentCommand>("test");
+
+            ////Act
+            var result = await processor.ProcessAsync(new string[] { "test", "first", "/datetime:2014-5-3 12:13:14", "/TestSwitch" });
+            var command = (MyArgumentCommand)result.Last().Command;
+
+            //// Assert
+            Assert.AreEqual(14, command.DateTime.Second);
+            Assert.AreEqual(13, command.DateTime.Minute);
+            Assert.AreEqual(12, command.DateTime.Hour);
+            Assert.AreEqual(3, command.DateTime.Day);
+            Assert.AreEqual(5, command.DateTime.Month);
+            Assert.AreEqual(2014, command.DateTime.Year);
+        }
+
+        [TestMethod]
+        public async Task When_running_command_with_incorrect_full_datetime_parameter_then_exception_is_thrown()
+        {
+            //// Arrange
+            var processor = new CommandLineProcessor(new ConsoleHost());
+            processor.RegisterCommand<MyArgumentCommand>("test");
+
+            ////Act
+            try
+            {
+                var result = await processor.ProcessAsync(new string[] { "test", "first", "/datetime:2014-5-3", "12:13:14", "/TestSwitch" });
+                var command = (MyArgumentCommand)result.Last().Command;
+                Assert.Fail();
+            }
+            catch (UnusedArgumentException ex)
+            {
+                Assert.AreEqual(ex.Message, "Unrecognised arguments are present.");
+            }
+        }
+
+        [TestMethod]
+        public async Task When_running_command_with_unexpected_arguments_then_exception_is_thrown()
+        {
+            //// Arrange
+            var processor = new CommandLineProcessor(new ConsoleHost());
+            processor.RegisterCommand<MyArgumentCommand>("test");
+
+            ////Act
+            try
+            {
+                var result = await processor.ProcessAsync(new string[] { "test", "first", "second", "third" });
+                var command = (MyArgumentCommand)result.Last().Command;
+                Assert.Fail();
+            }
+            catch (UnusedArgumentException ex)
+            {
+                Assert.AreEqual(ex.Message, "Unrecognised arguments are present.");
+            }
+        }
+
+        public class MyArgumentCommand : IConsoleCommand
+        {
+            [Argument(Name = "DateTime", IsRequired = false)]
+            public DateTime DateTime { get; set; } = DateTime.Parse("2015-1-1");
+
+            [Argument(Position = 1, IsRequired = false)]
+            public string First { get; set; }
+
+            [Switch(LongName = "TestSwitch", ShortName = "t")]
+            public bool Switch { get; set; }
+
+            public async Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/NConsole/ArgumentAttribute.cs
+++ b/src/NConsole/ArgumentAttribute.cs
@@ -31,23 +31,32 @@ namespace NConsole
         /// <param name="property">The property.</param>
         /// <param name="command">The command.</param>
         /// <param name="input">The output from the previous command in the chain.</param>
+        /// <param name="used">Indicates whether a value for the property was found in the given arguments.</param>
         /// <returns>The value.</returns>
         /// <exception cref="System.InvalidOperationException">Either the argument Name or Position can be set, but not both.</exception>
         /// <exception cref="InvalidOperationException">Either the argument Name or Position can be set, but not both.</exception>
         /// <exception cref="InvalidOperationException">The parameter has no default value.</exception>
-        public override object GetValue(IConsoleHost consoleHost, string[] args, PropertyInfo property, IConsoleCommand command, object input)
+        public override object GetValue(IConsoleHost consoleHost, string[] args, PropertyInfo property, IConsoleCommand command, object input, out bool used)
         {
             if (!string.IsNullOrEmpty(Name) && Position > 0)
                 throw new InvalidOperationException("Either the argument Name or Position can be set, but not both.");
 
+            used = false;
             string value = null;
 
             if (TryGetPositionalArgumentValue(args, out value))
+            {
+                used = true;
                 return ConvertToType(value, property.PropertyType);
+            }
+                
 
             if (TryGetNamedArgumentValue(args, out value))
+            {
+                used = true;
                 return ConvertToType(value, property.PropertyType);
-
+            }
+                
             if (AcceptsCommandInput && input != null)
                 return input;
 

--- a/src/NConsole/ArgumentAttributeBase.cs
+++ b/src/NConsole/ArgumentAttributeBase.cs
@@ -13,7 +13,7 @@ namespace NConsole
         /// <param name="command"></param>
         /// <param name="input">The output from the previous command in the chain.</param>
         /// <returns>The value.</returns>
-        public abstract object GetValue(IConsoleHost consoleHost, string[] args, PropertyInfo property, IConsoleCommand command, object input);
+        public abstract object GetValue(IConsoleHost consoleHost, string[] args, PropertyInfo property, IConsoleCommand command, object input, out bool used);
 
         /// <summary>Converts a string value to a specific type.</summary>
         /// <param name="value">The value.</param>

--- a/src/NConsole/CommandLineProcessor.cs
+++ b/src/NConsole/CommandLineProcessor.cs
@@ -6,12 +6,14 @@ using System.Threading.Tasks;
 
 namespace NConsole
 {
-    internal class UnusedArgumentException : Exception
+    /// <summary>An provided argument is not used.</summary>
+    public class UnusedArgumentException : Exception
     {
-        public UnusedArgumentException()
+        internal UnusedArgumentException()
             : base(string.Format("Unrecognised arguments are present."))
         { }
     }
+
     /// <summary>A command base command line processor.</summary>
     public class CommandLineProcessor
     {

--- a/src/NConsole/CommandLineProcessor.cs
+++ b/src/NConsole/CommandLineProcessor.cs
@@ -6,6 +6,12 @@ using System.Threading.Tasks;
 
 namespace NConsole
 {
+    internal class UnusedArgumentException : Exception
+    {
+        public UnusedArgumentException()
+            : base(string.Format("Unrecognised arguments are present."))
+        { }
+    }
     /// <summary>A command base command line processor.</summary>
     public class CommandLineProcessor
     {
@@ -119,6 +125,7 @@ namespace NConsole
         /// <exception cref="InvalidOperationException">No dependency resolver available to create a command without default constructor.</exception>
         public async Task<CommandResult> ProcessSingleAsync(string[] args, object input = null)
         {
+            var countOfArgsUsed = 0;
             var commandName = GetCommandName(args);
             if (_commands.ContainsKey(commandName))
             {
@@ -127,14 +134,20 @@ namespace NConsole
 
                 foreach (var property in commandType.GetRuntimeProperties())
                 {
+                    var used = false;
                     var argumentAttribute = property.GetCustomAttribute<ArgumentAttributeBase>();
                     if (argumentAttribute != null)
                     {
-                        var value = argumentAttribute.GetValue(_consoleHost, args, property, command, input);
+                        var value = argumentAttribute.GetValue(_consoleHost, args, property, command, input, out used);
                         if (value != null)
                             property.SetValue(command, value);
+                        if (used)
+                            countOfArgsUsed++;
                     }
                 }
+
+                if (countOfArgsUsed != args.Length - 1)
+                    throw new UnusedArgumentException();
 
                 var output = await command.RunAsync(this, _consoleHost);
                 return new CommandResult

--- a/src/NConsole/SwitchAttribute.cs
+++ b/src/NConsole/SwitchAttribute.cs
@@ -18,8 +18,9 @@ namespace NConsole
         /// <param name="command">The command.</param>
         /// <param name="input">The output from the previous command in the chain.</param>
         /// <returns>The value.</returns>
-        public override object GetValue(IConsoleHost consoleHost, string[] args, PropertyInfo property, IConsoleCommand command, object input)
+        public override object GetValue(IConsoleHost consoleHost, string[] args, PropertyInfo property, IConsoleCommand command, object input, out bool used)
         {
+            used = true;
             foreach (var argument in args)
             {
                 if (argument == "-" + ShortName)
@@ -27,8 +28,12 @@ namespace NConsole
 
                 if (argument == "--" + LongName)
                     return true;
+
+                if (argument == "/" + LongName)
+                    return true;
             }
 
+            used = false;
             return false; 
         }
     }


### PR DESCRIPTION
Currently there is no warning for unexpected arguments, this can result in user mistakes. eg. A user wants to parse /datetime:"2017-12-11 13:14:15" if they forget the quotes around it then this will result in two arguments "datetime:2017-12-11" and "13:14:15". In this case the date is then successfully converted to a DateTime 2017-12-11 00:00:00 and then time is lost and completely unused without anything noticing. My idea to solve this is to not allow unexpected arguments, I do this by counting the amount of properties used in the CommandLineProcessor and comparing to the length of the provided arguments, an exception will be thrown if they are not equal.